### PR TITLE
feat: Update session validation rules and remove customer ID exclusivity

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,12 +327,15 @@
                             </div>
 
                             <div class="mt-4">
-                                <label for="referenceText" class="block text-sm font-medium text-gray-700 mb-2">Reference Text</label>
+                                <label for="referenceText" class="block text-sm font-medium text-gray-700 mb-2">
+                                    Reference Text <span class="text-red-500">*</span>
+                                </label>
                                 <input 
                                     type="text" 
                                     id="referenceText" 
                                     placeholder="Reference for bank statement"
                                     class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+                                    required
                                 >
                             </div>
 

--- a/script.js
+++ b/script.js
@@ -188,8 +188,8 @@ function validateForm(formData) {
         errors.push('Scope is required');
     }
     
-    if (formData.customerId && formData.finionPayCustomerId) {
-        errors.push('Cannot specify both Customer ID and Finion Pay Customer ID');
+    if (formData.referenceText !== undefined && !formData.referenceText?.trim()) {
+        errors.push('Reference text cannot be empty when provided');
     }
     
     return errors;
@@ -372,17 +372,13 @@ function loadFromLocalStorage() {
             }
         }
         
-        // Trigger mutual exclusivity for customer ID fields
+        // Ensure customer ID fields are both enabled (mutual exclusivity removed)
         const customerIdField = document.getElementById('customerId');
         const finionPayCustomerIdField = document.getElementById('finionPayCustomerId');
-        if (customerIdField.value.trim()) {
-            finionPayCustomerIdField.disabled = true;
-            finionPayCustomerIdField.classList.add('bg-gray-100');
-        }
-        if (finionPayCustomerIdField.value.trim()) {
-            customerIdField.disabled = true;
-            customerIdField.classList.add('bg-gray-100');
-        }
+        customerIdField.disabled = false;
+        customerIdField.classList.remove('bg-gray-100');
+        finionPayCustomerIdField.disabled = false;
+        finionPayCustomerIdField.classList.remove('bg-gray-100');
         
         const savedDate = new Date(formData.timestamp);
         logStatus(`Form data restored from ${savedDate.toLocaleString()}`, 'success');
@@ -1186,28 +1182,19 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
     
-    // Add mutual exclusivity for customer ID fields
+    // Customer ID fields can now be used together (mutual exclusivity removed)
     const customerIdField = document.getElementById('customerId');
     const finionPayCustomerIdField = document.getElementById('finionPayCustomerId');
     
+    // Ensure both fields are always enabled
     customerIdField.addEventListener('input', () => {
-        if (customerIdField.value.trim()) {
-            finionPayCustomerIdField.disabled = true;
-            finionPayCustomerIdField.classList.add('bg-gray-100');
-        } else {
-            finionPayCustomerIdField.disabled = false;
-            finionPayCustomerIdField.classList.remove('bg-gray-100');
-        }
+        finionPayCustomerIdField.disabled = false;
+        finionPayCustomerIdField.classList.remove('bg-gray-100');
     });
     
     finionPayCustomerIdField.addEventListener('input', () => {
-        if (finionPayCustomerIdField.value.trim()) {
-            customerIdField.disabled = true;
-            customerIdField.classList.add('bg-gray-100');
-        } else {
-            customerIdField.disabled = false;
-            customerIdField.classList.remove('bg-gray-100');
-        }
+        customerIdField.disabled = false;
+        customerIdField.classList.remove('bg-gray-100');
     });
     
     // Handle redirect return if detected


### PR DESCRIPTION
## Summary
- Make reference text field mandatory when provided (cannot be null/empty)
- Remove mutual exclusivity between customerId and finionPayCustomerId fields  
- Allow both customer ID types to be provided simultaneously
- Add consistent UI styling for mandatory fields (red asterisk + required attribute)

## Changes Made

### Validation Logic (`script.js`)
- Updated `validateForm()` to require non-empty reference text when provided
- Removed validation error preventing both customer ID fields from being used together
- Updated UI event handlers to keep both customer ID fields always enabled
- Modified `loadFromLocalStorage()` to ensure both fields remain enabled on page load

### UI Updates (`index.html`)
- Added red asterisk (`*`) to Reference Text label to match other mandatory fields
- Added `required` attribute to reference text input field

## Test plan
- [x] Verify reference text validation works (empty strings are rejected when field is provided)
- [x] Verify both customer ID fields can be filled simultaneously 
- [x] Verify both customer ID fields remain enabled after typing in either one
- [x] Verify UI styling matches other mandatory fields (red asterisk visible)
- [x] Test form submission with both customer IDs provided
- [x] Test page reload preserves both customer ID values without disabling fields

🤖 Generated with [Claude Code](https://claude.ai/code)